### PR TITLE
SFTP-Storage: Correctly Sync mtime

### DIFF
--- a/apps/files_external/lib/Lib/Storage/SFTP.php
+++ b/apps/files_external/lib/Lib/Storage/SFTP.php
@@ -406,13 +406,10 @@ class SFTP extends \OC\Files\Storage\Common {
 	 */
 	public function touch($path, $mtime=null) {
 		try {
-			if (!is_null($mtime)) {
-				return false;
-			}
 			if (!$this->file_exists($path)) {
 				$this->getConnection()->put($this->absPath($path), '');
 			} else {
-				return false;
+				$this->getConnection()->touch($this->absPath($path), $mtime);
 			}
 		} catch (\Exception $e) {
 			return false;


### PR DESCRIPTION
Currently uploading a file to an external SFTP storage does not keep the mtime.
Besides losing this information is bad by itself, fast repeated changing / syncing of a file on the external storage, creates conflicts randomly (maybe if a change happens during the upload?).

Using the provided change, I was not able to reproduce the issue anymore.